### PR TITLE
Implement mutual information caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,11 @@ N/A
 * Create the libs/ directory and download spmf.jar, which is a JAR file for the SPMF library (download link is also here: http://www.philippe-fournier-viger.com/spmf/index.php?link=download.php)
 * Builds frequent patterns for authors and title terms -- data/frequent_author_patterns.txt and data/frequent_title_term_patterns.txt, where all words are mapped to unique ids and the id mapping is cached in these 2 files respectively: data/author_id_mappings.txt and data/title_term_id_mappings.txt. The code that builds these files is here: utils/frequent_pattern_mining/build_frequent_patterns.py
 * Removes redundancies from sequential frequent title patterns (data/title_term_id_mappings.txt) and creates a new file called data/minimal_title_term_patterns.txt containing these minimal patterns
+* Builds a file to cache all mutual information values between pairs of author patterns
 
 RELEVANT OUTPUT FILES FOR NEXT STAGE:
 * data/frequent_author_patterns.txt (ID mappings: data/author_id_mappings.txt)
-* data/minimal_title_term_patterns.txt (ID mappings: data/title_term_id_mappings.txt
+* data/minimal_title_term_patterns.txt (ID mappings: data/title_term_id_mappings.txt)
+* data/author_mutual_info_patterns.txt
 
 NOTE: utils/parse_patterns.py contains utility methods to parse patterns into data structures and write them to files, you may find these methods useful

--- a/setup.sh
+++ b/setup.sh
@@ -27,11 +27,14 @@ cd ..
 echo "Mining frequent patterns"
 python utils/frequent_pattern_mining/build_frequent_patterns.py
 
-echo "Removing redudancies from sequencial title term patterns"
+echo "Removing redudancies from sequential title term patterns"
 python utils/remove_redundant_patterns.py
 
+echo "Computing author-author pattern mutual information cache"
+python utils/mutual_information_manager.py
+
 echo "Checking to make sure all required files exist"
-declare -a required_files=("data/frequent_author_patterns.txt" "data/author_id_mappings.txt" "data/title_term_id_mappings.txt" "data/title_term_id_mappings.txt")
+declare -a required_files=("data/frequent_author_patterns.txt" "data/author_id_mappings.txt" "data/title_term_id_mappings.txt" "data/title_term_id_mappings.txt", "data/author_mutual_info_patterns.txt")
 for i in "${required_files[@]}"
 do
 if [ -e $i ]

--- a/utils/frequent_pattern_mining/build_frequent_patterns.py
+++ b/utils/frequent_pattern_mining/build_frequent_patterns.py
@@ -28,7 +28,7 @@ class FrequentPatternBuilder():
     AUTHOR_ID_FILE_PATH = "data/author_id_mappings.txt"
     TITLE_TERM_ID_FILE_PATH = "data/title_term_id_mappings.txt"
 
-    def __init__(self, fp_close_thresh=0.01, clospan_thresh=0.075, display_transaction_nums=False):
+    def __init__(self, fp_close_thresh=0.05, clospan_thresh=0.075, display_transaction_nums=False):
         '''
         @param fp_close_thresh          Min relative (percentage) support for FPClose
         @param clospan_thresh           Min relative (percentage) support for CloSpan
@@ -162,4 +162,4 @@ class FrequentPatternBuilder():
 if __name__ == "__main__":
     pattern_builder = FrequentPatternBuilder()
     pattern_builder.build_frequent_pattern_files()
-    pattern_builder.clean_intermediate_files()
+    # pattern_builder.clean_intermediate_files()

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -51,6 +51,13 @@ class MutualInformationManager:
         print(max(mi))
         print(min(mi))
 
+    def get_mutual_information(self, pattern_index_x, pattern_index_y):
+        if pattern_index_x <= pattern_index_y:
+            ind_tup = (pattern_index_x, pattern_index_y)
+        else:
+            ind_tup = (pattern_index_y, pattern_index_x)
+        return self.__mutual_info_vals[ind_tup]
+
     def __compute_mutual_information(self, pattern_x, pattern_y):
         if not transactions:
             print("You can't compute mutual information with a null transactions manager")

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -143,21 +143,22 @@ class MutualInformationManager:
         print(x_y_intersection_len, x_y_union_len, x_support, y_support)
         num_transactions = self.__transactions.get_number_of_transactions()
 
-        p_x = x_support / num_transactions
-        p_y = y_support / num_transactions
+        p_x_1 = x_support / num_transactions
+        p_y_1 = y_support / num_transactions
+        p_x_0 = (num_transactions - x_support) / num_transactions
+        p_y_0 = (num_transactions - y_support) / num_transactions
+
         p_x_1_y_1 = x_y_intersection_len / num_transactions
         p_x_0_y_1 = (y_support - x_y_intersection_len) / num_transactions
         p_x_1_y_0 = (x_support - x_y_intersection_len) / num_transactions
         p_x_0_y_0 = (num_transactions - x_y_union_len) / num_transactions
+        
+        mi_x_1_y_1 = p_x_1_y_1 / log2(p_x_1_y_1 / p_x_1 / p_y_1)
+        mi_x_1_y_0 = p_x_1_y_0 / log2(p_x_1_y_0 / p_x_1 / p_y_0)
+        mi_x_0_y_1 = p_x_0_y_1 / log2(p_x_0_y_1 / p_x_0 / p_y_1)
+        mi_x_0_y_0 = p_x_0_y_0 / log2(p_x_0_y_0 / p_x_0 / p_y_0)
 
-        def compute_mutual_info_given_probs(p_x_y):
-            print(p_x_y)
-            return p_x_y * log2(p_x_y / (p_x * p_y))
-
-        mi = compute_mutual_info_given_probs(p_x_1_y_1) \
-            + compute_mutual_info_given_probs(p_x_0_y_1) \
-            + compute_mutual_info_given_probs(p_x_1_y_0) \
-            + compute_mutual_info_given_probs(p_x_0_y_0)
+        mi = mi_x_1_y_1 + mi_x_1_y_0 + mi_x_0_y_1 + mi_x_0_y_0
         print(mi)
         return mi
 

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -79,7 +79,7 @@ class MutualInformationManager:
         Computes mutual information for pattern indices (a, b) given that a <= b. In other words, it
         computes a triangular matrix of mutual information values bc MI is symmetric
         '''
-        if not transactions:
+        if not self.__transactions:
             print("You can't compute mutual information with a null transactions manager")
             return
 
@@ -124,7 +124,7 @@ class MutualInformationManager:
 
         @return mutual information val, which is represented as a float
         '''
-        if not transactions:
+        if not self.__transactions:
             print("You can't compute mutual information with a null transactions manager")
             return
 

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -1,0 +1,60 @@
+from math import log2
+from transactions_manager import TransactionsManager
+from parse_patterns import parse_file_into_patterns
+
+class MutualInformationManager:
+    def __init__(self, transactions):
+        # Dictionary of (pattern index a, pattern index b) pairs where
+        # a <= b (aka a triangular matrix)
+        self.__mutual_info_vals = {}
+        self.__transactions = transactions
+
+    def read_mutual_information_from_file(self, filename):
+        pass
+
+    def compute_mutual_information(self, patterns):
+        num_patterns = len(patterns)
+        mi = []
+        for ind_x, pattern_x in enumerate(patterns):
+            for ind_y in range(ind_x, num_patterns):
+
+                self.__mutual_info_vals[(ind_x, ind_y)] = \
+                    self.__compute_mutual_information(pattern_x, patterns[ind_y])
+                mi.append(self.__mutual_info_vals[(ind_x, ind_y)])
+        print(max(mi))
+        print(min(mi))
+
+    def __compute_mutual_information(self, pattern_x, pattern_y):
+        # Compute intersection
+        pattern_x_set = set(pattern_x)
+        pattern_y_set = set(pattern_y)
+
+        x_y_intersection_support = self.__transactions.find_author_pattern_support(\
+            pattern_x_set.intersection(pattern_y_set))
+        x_y_union_support = self.__transactions.find_author_pattern_support(\
+            pattern_x_set.union(pattern_y_set))
+        x_support = self.__transactions.find_author_pattern_support(pattern_x_set)
+        y_support = self.__transactions.find_author_pattern_support(pattern_y_set)
+
+        num_transactions = self.__transactions.get_number_of_transactions()
+
+        p_x = x_support / num_transactions
+        p_y = y_support / num_transactions
+        p_x_1_y_1 = x_y_intersection_support / num_transactions
+        p_x_0_y_1 = (y_support - x_y_intersection_support) / num_transactions
+        p_x_1_y_0 = (x_support - x_y_intersection_support) / num_transactions
+        p_x_0_y_0 = (num_transactions - x_y_union_support) / num_transactions
+
+        def compute_mutual_info_given_probs(p_x_y):
+            return (p_x_y + 1) * log2((p_x_y + 1) / ((p_x + 1) * (p_y + 1)))
+
+        return compute_mutual_info_given_probs(p_x_1_y_1) \
+            + compute_mutual_info_given_probs(p_x_0_y_1) \
+            + compute_mutual_info_given_probs(p_x_1_y_0) \
+            + compute_mutual_info_given_probs(p_x_0_y_0)
+
+if __name__ == "__main__":
+    transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
+    author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
+    mutual_info = MutualInformationManager(transactions)
+    mutual_info.compute_mutual_information(author_patterns)

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -8,11 +8,12 @@ class MutualInformationManager:
 
     AUTHOR_MUTUAL_INFO_FILENAME = os.path.join("data", "author_mutual_info_patterns.txt")
 
-    def __init__(self, transactions=None):
+    def __init__(self, transactions=None, write_to_file_during_computation=False):
         # Dictionary of (pattern index a, pattern index b) pairs where
         # a <= b (aka a triangular matrix)
         self.__mutual_info_vals = {}
         self.__transactions = transactions
+        self.__write_to_file_during_computation = write_to_file_during_computation
 
     def read_mutual_information_from_file(self):
         mutual_info_file = open(MutualInformationManager.AUTHOR_MUTUAL_INFO_FILENAME, "r")
@@ -28,6 +29,10 @@ class MutualInformationManager:
         mutual_info_file.close()
 
     def write_mutual_information_to_file(self):
+        if self.__write_to_file_during_computation:
+            print("You've already written this information to a file")
+            return
+
         # Format: pattern_ind_1 pattern_ind_2 MI
         mutual_info_file = open(MutualInformationManager.AUTHOR_MUTUAL_INFO_FILENAME, "w")
         for pattern_ind_x, pattern_ind_y in self.__mutual_info_vals:
@@ -40,6 +45,9 @@ class MutualInformationManager:
             print("You can't compute mutual information with a null transactions manager")
             return
 
+        if self.__write_to_file_during_computation:
+            mutual_info_file = open(MutualInformationManager.AUTHOR_MUTUAL_INFO_FILENAME, "w")
+
         num_patterns = len(patterns)
         mi = []
         for ind_x, pattern_x in enumerate(patterns):
@@ -48,6 +56,14 @@ class MutualInformationManager:
                 self.__mutual_info_vals[(ind_x, ind_y)] = \
                     self.__compute_mutual_information(pattern_x, patterns[ind_y])
                 mi.append(self.__mutual_info_vals[(ind_x, ind_y)])
+                print(ind_x, ind_y, self.__mutual_info_vals[(ind_x, ind_y)])
+
+                if self.__write_to_file_during_computation:
+                    mutual_info_file.write("%d %d %f\n" % (ind_x, ind_y, \
+                        self.__mutual_info_vals[(ind_x, ind_y)]))
+        if self.__write_to_file_during_computation:
+            mutual_info_file.close()
+                   
         print(max(mi))
         print(min(mi))
 
@@ -94,6 +110,6 @@ class MutualInformationManager:
 if __name__ == "__main__":
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
     author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
-    mutual_info = MutualInformationManager(transactions)
+    mutual_info = MutualInformationManager(transactions, True)
     mutual_info.compute_mutual_information(author_patterns)
-    mutual_info.write_mutual_information_to_file()
+    # mutual_info.write_mutual_information_to_file()

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -2,17 +2,44 @@ from math import log2
 from transactions_manager import TransactionsManager
 from parse_patterns import parse_file_into_patterns
 
+import os
+
 class MutualInformationManager:
-    def __init__(self, transactions):
+
+    AUTHOR_MUTUAL_INFO_FILENAME = os.path.join("data", "author_mutual_info_patterns.txt")
+
+    def __init__(self, transactions=None):
         # Dictionary of (pattern index a, pattern index b) pairs where
         # a <= b (aka a triangular matrix)
         self.__mutual_info_vals = {}
         self.__transactions = transactions
 
-    def read_mutual_information_from_file(self, filename):
-        pass
+    def read_mutual_information_from_file(self):
+        mutual_info_file = open(MutualInformationManager.AUTHOR_MUTUAL_INFO_FILENAME, "r")
+        for line in mutual_info_file:
+            mutual_info_lst = line.strip.split()
+            assert len(mutual_info_lst) == 3
+
+            ind_x = int(mutual_info_lst[0])
+            ind_y = int(mutual_info_lst[1])
+            assert ind_x <= ind_y
+
+            self.__mutual_info_vals[(ind_x, ind_y)] = float(mutual_info_lst[2])
+        mutual_info_file.close()
+
+    def write_mutual_information_to_file(self):
+        # Format: pattern_ind_1 pattern_ind_2 MI
+        mutual_info_file = open(MutualInformationManager.AUTHOR_MUTUAL_INFO_FILENAME, "w")
+        for pattern_ind_x, pattern_ind_y in self.__mutual_info_vals:
+            mutual_info_file.write("%d %d %f\n" % (pattern_ind_x, pattern_ind_y, \
+                self.__mutual_info_vals[(pattern_ind_x, pattern_ind_y)]))
+        mutual_info_file.close()
 
     def compute_mutual_information(self, patterns):
+        if not transactions:
+            print("You can't compute mutual information with a null transactions manager")
+            return
+
         num_patterns = len(patterns)
         mi = []
         for ind_x, pattern_x in enumerate(patterns):
@@ -25,6 +52,10 @@ class MutualInformationManager:
         print(min(mi))
 
     def __compute_mutual_information(self, pattern_x, pattern_y):
+        if not transactions:
+            print("You can't compute mutual information with a null transactions manager")
+            return
+
         # Compute intersection
         pattern_x_set = set(pattern_x)
         pattern_y_set = set(pattern_y)
@@ -58,3 +89,4 @@ if __name__ == "__main__":
     author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
     mutual_info = MutualInformationManager(transactions)
     mutual_info.compute_mutual_information(author_patterns)
+    mutual_info.write_mutual_information_to_file()

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -27,7 +27,7 @@ class MutualInformationManager:
 
     # TODO pass this in as a param, make this code more flexible st we can use it for authors and
     # title patterns
-    AUTHOR_MUTUAL_INFO_FILENAME = os.path.join("data", "author_mutual_info_patterns.txt")
+    AUTHOR_MUTUAL_INFO_FILENAME = os.path.join("data", "test.txt")
 
     def __init__(self, transactions=None, write_to_file_during_computation=False):
         '''
@@ -132,35 +132,41 @@ class MutualInformationManager:
         pattern_x_set = set(pattern_x)
         pattern_y_set = set(pattern_y)
 
-        x_y_intersection_support = self.__transactions.find_author_pattern_support(\
-            pattern_x_set.intersection(pattern_y_set))
-        x_y_union_support = self.__transactions.find_author_pattern_support(\
-            pattern_x_set.union(pattern_y_set))
-        x_support = self.__transactions.find_author_pattern_support(pattern_x_set)
-        y_support = self.__transactions.find_author_pattern_support(pattern_y_set)
+        x_paper_inds = self.__transactions.find_author_pattern_transactions_ids(pattern_x_set)
+        y_paper_inds = self.__transactions.find_author_pattern_transactions_ids(pattern_y_set)
+        x_support = len(x_paper_inds)
+        y_support = len(y_paper_inds)
 
+        x_y_intersection_len = len(x_paper_inds.intersection(y_paper_inds))
+        x_y_union_len = len(x_paper_inds.union(y_paper_inds))
+
+        print(x_y_intersection_len, x_y_union_len, x_support, y_support)
         num_transactions = self.__transactions.get_number_of_transactions()
 
         p_x = x_support / num_transactions
         p_y = y_support / num_transactions
-        p_x_1_y_1 = x_y_intersection_support / num_transactions
-        p_x_0_y_1 = (y_support - x_y_intersection_support) / num_transactions
-        p_x_1_y_0 = (x_support - x_y_intersection_support) / num_transactions
-        p_x_0_y_0 = (num_transactions - x_y_union_support) / num_transactions
+        p_x_1_y_1 = x_y_intersection_len / num_transactions
+        p_x_0_y_1 = (y_support - x_y_intersection_len) / num_transactions
+        p_x_1_y_0 = (x_support - x_y_intersection_len) / num_transactions
+        p_x_0_y_0 = (num_transactions - x_y_union_len) / num_transactions
 
         def compute_mutual_info_given_probs(p_x_y):
-            return (p_x_y + 1) * log2((p_x_y + 1) / ((p_x + 1) * (p_y + 1)))
+            print(p_x_y)
+            return p_x_y * log2(p_x_y / (p_x * p_y))
 
-        return compute_mutual_info_given_probs(p_x_1_y_1) \
+        mi = compute_mutual_info_given_probs(p_x_1_y_1) \
             + compute_mutual_info_given_probs(p_x_0_y_1) \
             + compute_mutual_info_given_probs(p_x_1_y_0) \
             + compute_mutual_info_given_probs(p_x_0_y_0)
+        print(mi)
+        return mi
 
 if __name__ == "__main__":
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
     author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
     mutual_info = MutualInformationManager(transactions, True)
-    mutual_info.compute_mutual_information(author_patterns)
-    mutual_info.write_mutual_information_to_file()
+    mutual_info.compute_mutual_information(author_patterns[:10])
+    # mutual_info.write_mutual_information_to_file()
+    
     # mutual_info = MutualInformationManager()
     # mutual_info.read_mutual_information_from_file()

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -49,7 +49,7 @@ class MutualInformationManager:
         '''
         mutual_info_file = open(MutualInformationManager.AUTHOR_MUTUAL_INFO_FILENAME, "r")
         for line in mutual_info_file:
-            mutual_info_lst = line.strip.split()
+            mutual_info_lst = line.strip().split()
             assert len(mutual_info_lst) == 3
 
             ind_x = int(mutual_info_lst[0])
@@ -87,23 +87,16 @@ class MutualInformationManager:
             mutual_info_file = open(MutualInformationManager.AUTHOR_MUTUAL_INFO_FILENAME, "w")
 
         num_patterns = len(patterns)
-        mi = []
         for ind_x, pattern_x in enumerate(patterns):
             for ind_y in range(ind_x, num_patterns):
-
                 self.__mutual_info_vals[(ind_x, ind_y)] = self.compute_mutual_information_for_pattern_pair(pattern_x, patterns[ind_y])
-                mi.append(self.__mutual_info_vals[(ind_x, ind_y)])
-                print(ind_x, ind_y, self.__mutual_info_vals[(ind_x, ind_y)])
 
                 if self.__write_to_file_during_computation:
                     mutual_info_file.write("%d %d %f\n" % (ind_x, ind_y, \
                         self.__mutual_info_vals[(ind_x, ind_y)]))
         if self.__write_to_file_during_computation:
             mutual_info_file.close()
-                   
-        print(max(mi))
-        print(min(mi))
-
+                  
     def get_mutual_information(self, pattern_index_x, pattern_index_y):
         '''
         Get precomputed mutual information value given 2 indices. Assumes that the mutual info matrix has been
@@ -168,4 +161,6 @@ if __name__ == "__main__":
     author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
     mutual_info = MutualInformationManager(transactions, True)
     mutual_info.compute_mutual_information(author_patterns)
-    # mutual_info.write_mutual_information_to_file()
+    mutual_info.write_mutual_information_to_file()
+    # mutual_info = MutualInformationManager()
+    # mutual_info.read_mutual_information_from_file()

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -55,30 +55,22 @@ class TransactionsManager:
             term_ids = []
             for title_term in title.split():
                 term_ids.append(self.__title_terms_mapping[title_term])
-
             self.__papers.append(TransactionsManager.Paper(author_ids, term_ids))
 
         papers_file.close()
     
-    def find_author_pattern_support(self, author_pattern):
+    def find_author_pattern_transactions_ids(self, author_pattern):
         '''
-        Compute the support of a given author pattern wrt the parsed papers
+        Find transactions that have author pattern as a subset
 
         @param:
             author_pattern: Collection(int)     Collection of author ids
         '''
-        support = 0
-        for paper in self.__papers:
-            # NOTE: This wasn't working -- if author_pattern.issubset(paper.authors)
-            # TODO object decomp: this part makes more sense within the Papers class
-            is_subset = True
-            for author in paper.authors:
-                if author not in author_pattern:
-                    is_subset = False
-                    break
-            if is_subset:
-                support += 1
-        return support
+        author_transactions = set()
+        for ind, paper in enumerate(self.__papers):
+            if author_pattern.issubset(paper.authors):
+                author_transactions.add(ind)
+        return author_transactions
 
     def get_number_of_transactions(self):
         '''

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -23,10 +23,10 @@ class TransactionsManager:
             # Note: Titles are guaranteed to not have commas
             line_as_lst = line.split(',')
             authors = line_as_lst[ : -1]
-            author_ids = []
+            author_ids = set()
 
             for author in authors:
-                author_ids.append(self.__authors_mapping[author])
+                author_ids.add(self.__authors_mapping[author])
             
             title = line_as_lst[-1]
             term_ids = []
@@ -37,6 +37,22 @@ class TransactionsManager:
 
         papers_file.close()
     
+    def find_author_pattern_support(self, author_pattern):
+        support = 0
+        for paper in self.__papers:
+            # NOTE: This wasn't working -- if author_pattern.issubset(paper.authors)
+            is_subset = True
+            for author in paper.authors:
+                if author not in author_pattern:
+                    is_subset = False
+                    break
+            if is_subset:
+                support += 1
+        return support
+
+    def get_number_of_transactions(self):
+        return len(self.__papers)
+
     @staticmethod
     def __parse_mapping(mapping_filename, mapping):
         mapping_file = open(mapping_filename, "r")
@@ -45,7 +61,7 @@ class TransactionsManager:
             id_word_lst = line.strip().split()
             assert len(id_word_lst) == 2
             assert id_word_lst[1] not in mapping
-            mapping[id_word_lst[1]] = id_word_lst[0]
+            mapping[id_word_lst[1]] = int(id_word_lst[0])
 
         mapping_file.close()
 

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -1,12 +1,35 @@
+'''
+Encapsulates all papers (aka data.csv) and provides utility methods
+'''
 class TransactionsManager:
 
+    '''
+    Represents a single paper
+    '''
     class Paper:
         def __init__(self, authors, title):
+            '''
+            @param
+                authors: Collection(int)    Collection of author ids
+                title: list(int)            Ordered list of title word ids
+            
+            IMPORTANT: Both collections must store integers (to correctly compute the
+            support of a certain pattern)
+            '''
             self.authors = authors
             self.title = title
 
     def __init__(self, papers_file_name, authors_mapping_filename, \
                 title_terms_mapping_filename):
+        '''
+        Parses and stores the author-id mapping, the title terms-id mapping, and
+        a list of all papers
+
+        @param
+            papers_file_name: string                data.csv file path
+            authors_mapping_filename: string        file path to author-id mapping file
+            title_terms_mapping_filename: string    file path to title term-id mapping file
+        '''
         papers_file = open(papers_file_name, "r")
         
         # {Author name, id}
@@ -38,9 +61,16 @@ class TransactionsManager:
         papers_file.close()
     
     def find_author_pattern_support(self, author_pattern):
+        '''
+        Compute the support of a given author pattern wrt the parsed papers
+
+        @param:
+            author_pattern: Collection(int)     Collection of author ids
+        '''
         support = 0
         for paper in self.__papers:
             # NOTE: This wasn't working -- if author_pattern.issubset(paper.authors)
+            # TODO object decomp: this part makes more sense within the Papers class
             is_subset = True
             for author in paper.authors:
                 if author not in author_pattern:
@@ -51,10 +81,20 @@ class TransactionsManager:
         return support
 
     def get_number_of_transactions(self):
+        '''
+        Returns the number of papers, aka the number of transactions
+        '''
         return len(self.__papers)
 
     @staticmethod
     def __parse_mapping(mapping_filename, mapping):
+        '''
+        Parses a mapping from a file into a dictionary
+
+        @param
+            mapping_filename: string        Filename containing id-word mapping
+            mapping: dict(string, int)      Mapping dict to be populated
+        '''
         mapping_file = open(mapping_filename, "r")
 
         for line in mapping_file:

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -1,0 +1,53 @@
+class TransactionsManager:
+
+    class Paper:
+        def __init__(self, authors, title):
+            self.authors = authors
+            self.title = title
+
+    def __init__(self, papers_file_name, authors_mapping_filename, \
+                title_terms_mapping_filename):
+        papers_file = open(papers_file_name, "r")
+        
+        # {Author name, id}
+        self.__authors_mapping = {}
+        TransactionsManager.__parse_mapping(authors_mapping_filename, self.__authors_mapping)
+
+        # {Title term, id}
+        self.__title_terms_mapping = {}
+        TransactionsManager.__parse_mapping(title_terms_mapping_filename, self.__title_terms_mapping)
+
+        self.__papers = []
+
+        for line in papers_file:
+            # Note: Titles are guaranteed to not have commas
+            line_as_lst = line.split(',')
+            authors = line_as_lst[ : -1]
+            author_ids = []
+
+            for author in authors:
+                author_ids.append(self.__authors_mapping[author])
+            
+            title = line_as_lst[-1]
+            term_ids = []
+            for title_term in title.split():
+                term_ids.append(self.__title_terms_mapping[title_term])
+
+            self.__papers.append(TransactionsManager.Paper(author_ids, term_ids))
+
+        papers_file.close()
+    
+    @staticmethod
+    def __parse_mapping(mapping_filename, mapping):
+        mapping_file = open(mapping_filename, "r")
+
+        for line in mapping_file:
+            id_word_lst = line.strip().split()
+            assert len(id_word_lst) == 2
+            assert id_word_lst[1] not in mapping
+            mapping[id_word_lst[1]] = id_word_lst[0]
+
+        mapping_file.close()
+
+if __name__ == "__main__":
+    transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")


### PR DESCRIPTION
# Summary
* Implement mutual info caching by writing all mutual infos (for each pair of indices st index 1 <= index 2) to a file
* Implement transaction manager to parse and manage each paper in data.csv

Files of interest:
* utils/mutual_information_manager.py. Use to read the mutual info file into this class and to get the mutual information given a pair of indices. Don't worry about computing the mutual infos, everything shoudl be cached. Usage:
     mutual_info = MutualInformationManager()
     mutual_info.read_mutual_information_from_file()
     mutual_info.get_mutual_information(1, 2) # to get mutual info for patterns 1 and 2

* utils/transactions_manager.py. Manages the transactions in the db
    transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
