### PR TITLE
Add support for title experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,13 @@ N/A
 * Create the libs/ directory and download spmf.jar, which is a JAR file for the SPMF library (download link is also here: http://www.philippe-fournier-viger.com/spmf/index.php?link=download.php)
 * Builds frequent patterns for authors and title terms -- data/frequent_author_patterns.txt and data/frequent_title_term_patterns.txt, where all words are mapped to unique ids and the id mapping is cached in these 2 files respectively: data/author_id_mappings.txt and data/title_term_id_mappings.txt. The code that builds these files is here: utils/frequent_pattern_mining/build_frequent_patterns.py
 * Removes redundancies from sequential frequent title patterns (data/title_term_id_mappings.txt) and creates a new file called data/minimal_title_term_patterns.txt containing these minimal patterns
-* Builds a file to cache all mutual information values between pairs of author patterns
+* Builds files to cache all mutual information values between pairs of author patterns, between pairs of author-title patterns, and between pairs of title patterns
 
 RELEVANT OUTPUT FILES FOR NEXT STAGE:
 * data/frequent_author_patterns.txt (ID mappings: data/author_id_mappings.txt)
 * data/minimal_title_term_patterns.txt (ID mappings: data/title_term_id_mappings.txt)
-* data/author_mutual_info_patterns.txt
+* data/author_author_mutual_info_patterns.txt
+* data/author_title_mutual_info_patterns.txt
+* data/title_title_mutual_info_patterns.txt
 
 NOTE: utils/parse_patterns.py contains utility methods to parse patterns into data structures and write them to files, you may find these methods useful

--- a/pattern_annotators/representative_transaction_extractor.py
+++ b/pattern_annotators/representative_transaction_extractor.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "utils"))
 
 from transactions_manager import TransactionsManager
 from mutual_information_manager import MutualInformationManager
-from parse_patterns import parse_file_into_patterns
+from parse_patterns import parse_author_file_into_patterns
 from cosine_similarity import compute_cosine_similarity
 
 '''
@@ -102,11 +102,11 @@ class RepresentativeTransactionExtractor:
             print()
 
 if __name__ == "__main__":
-    mutual_info = MutualInformationManager()
+    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR)
     mutual_info.read_mutual_information_from_file()    
 
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
-    author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
+    author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
     
     extractor = RepresentativeTransactionExtractor(transactions, mutual_info, author_patterns, 3, True)
     repr_transactions = extractor.find_representative_transactions()

--- a/pattern_annotators/representative_transaction_extractor.py
+++ b/pattern_annotators/representative_transaction_extractor.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "utils"))
 
 from transactions_manager import TransactionsManager
 from mutual_information_manager import MutualInformationManager
-from parse_patterns import parse_author_file_into_patterns
+from parse_patterns import parse_author_file_into_patterns, parse_sequential_title_file_into_patterns
 from cosine_similarity import compute_cosine_similarity
 
 '''
@@ -30,12 +30,13 @@ class RepresentativeTransactionExtractor:
         def __eq__(self, other): 
             return self.cosine_sim == other.cosine_sim
 
-    def __init__(self, transaction_mananger, mutual_info_manager, patterns, num_transactions, is_author):
+    def __init__(self, transaction_mananger, mutual_info_manager, patterns, pattern_type, num_transactions, is_author):
         '''
         @param
             transaction_mananger: TransactionsManager       Object storing all transactions (every line from data.csv)
             mutual_info_manager: MutualInformationManager   Object storing a set of all author-author mutual information vals
             patterns: list(list(int))                       List of all SSP patterns
+            pattern_type: PatternType                       Type of pattern pairs to compute MI for
             num_transactions: int                           Top k most representative transactions to find
             is_author: bool                                 True if SSP == authors, false otherwise
         '''
@@ -43,6 +44,10 @@ class RepresentativeTransactionExtractor:
         self.__mutual_info_manager = mutual_info_manager
 
         self.__patterns = patterns
+        assert pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+            or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE
+        self.__pattern_type = pattern_type
+
         self.__num_transactions = num_transactions
         self.__is_author = is_author
 
@@ -57,7 +62,11 @@ class RepresentativeTransactionExtractor:
         @return list(int):
             k most semantically similar patterns, sorted in decreasing similarity
         '''
-        paper_context_models = self.__transaction_manager.compute_author_context_models(self.__patterns)
+        if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
+            paper_context_models = self.__transaction_manager.compute_author_context_models(self.__patterns)
+        elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+             paper_context_models = self.__transaction_manager.compute_title_context_models(self.__patterns)
+           
         context_model_dim = len(self.__patterns)
 
         similarities_max_q = []
@@ -85,15 +94,40 @@ class RepresentativeTransactionExtractor:
         top_transactions list(int):         list of all indices (aka ids) of the papers ordered from
             most representative to least representative and of size num_transactions
         '''
+        if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
+            self.__display_pretty_authors_pattern_title_transactions(pattern_id, top_transactions)
+        elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+            self.__display_pretty_title_pattern_transactions(pattern_id, top_transactions)
+
+    def __display_pretty_authors_pattern_title_transactions(self, pattern_id, top_transactions):
         pattern = self.__patterns[pattern_id]
+
         pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in pattern]
         print("Input pattern: %s" % ' '.join(pattern_words))
+        self.__display_title_terms(top_transactions)
 
+    def __display_pretty_title_pattern_transactions(self, pattern_id, top_transactions):
+        pattern = self.__patterns[pattern_id]
+
+        pattern_words = [self.__transaction_manager.get_title_term(word_id) for word_id in pattern]
+        print("Input pattern: %s" % ' '.join(pattern_words))
+
+        self.__display_title_terms(top_transactions)
+
+        for transaction_ind in top_transactions:
+            transaction_auth_ids = self.__transaction_manager.get_paper_authors(transaction_ind)
+            transaction_auth_words = [self.__transaction_manager.get_author_name(word_id) \
+                for word_id in transaction_auth_ids]
+            print("Most representative title transactions %d: %s" % \
+                (transaction_ind, ' '.join(transaction_auth_words)))
+        print()
+
+    def __display_title_terms(self, top_transactions):
         for transaction_ind in top_transactions:
             transaction_title_ids = self.__transaction_manager.get_paper_title_terms(transaction_ind)
             transaction_title_words = [self.__transaction_manager.get_title_term(word_id) \
                 for word_id in transaction_title_ids]
-            print("Most representative transaction %d: %s" % \
+            print("Most representative title transactions %d: %s" % \
                 (transaction_ind, ' '.join(transaction_title_words)))
         print()
 
@@ -109,7 +143,14 @@ if __name__ == "__main__":
 
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
     author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
+    title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
     
-    extractor = RepresentativeTransactionExtractor(transactions, mutual_info, author_patterns, 3, True)
+    '''
+    extractor = RepresentativeTransactionExtractor(transactions, mutual_info, author_patterns, \
+        MutualInformationManager.PatternType.AUTHOR_AUTHOR, 3, True)
+    '''
+    extractor = RepresentativeTransactionExtractor(transactions, mutual_info, title_patterns, \
+        MutualInformationManager.PatternType.TITLE_TITLE, 3, True)
+    
     repr_transactions = extractor.find_representative_transactions(target_id, k)
     extractor.display_pretty(target_id, repr_transactions)

--- a/pattern_annotators/semantically_similar_pattern_extractor.py
+++ b/pattern_annotators/semantically_similar_pattern_extractor.py
@@ -109,7 +109,7 @@ if __name__ == '__main__':
         mutual_info.read_mutual_information_from_file()
 
         title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
-        extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, author_patterns, \
+        extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, title_patterns, \
             MutualInformationManager.PatternType.TITLE_TITLE)
     
     strongest_similarity = extractor.find_semantically_similar_patterns(target_id, k)

--- a/pattern_annotators/semantically_similar_pattern_extractor.py
+++ b/pattern_annotators/semantically_similar_pattern_extractor.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "utils"))
 
 from transactions_manager import TransactionsManager
 from mutual_information_manager import MutualInformationManager
-from parse_patterns import parse_file_into_patterns
+from parse_patterns import parse_author_file_into_patterns
 from cosine_similarity import compute_cosine_similarity
 
 class SemanticallySimilarPatternExtractor:
@@ -82,11 +82,13 @@ if __name__ == '__main__':
     '''
     target_id = int(sys.argv[1])
     k = int(sys.argv[2])
-    mutual_info = MutualInformationManager()
-    mutual_info.read_mutual_information_from_file()
-    transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")
-    author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
 
-    extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, author_patterns)
+    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR)
+    mutual_info.read_mutual_information_from_file()
+
+    transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")
+    author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
+
+    extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, author_patterns[:4])
     strongest_similarity = extractor.find_semantically_similar_patterns(target_id, k)
     extractor.pretty_print(target_id, strongest_similarity)

--- a/pattern_annotators/semantically_similar_pattern_extractor.py
+++ b/pattern_annotators/semantically_similar_pattern_extractor.py
@@ -89,6 +89,6 @@ if __name__ == '__main__':
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")
     author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
 
-    extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, author_patterns[:4])
+    extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, author_patterns)
     strongest_similarity = extractor.find_semantically_similar_patterns(target_id, k)
     extractor.pretty_print(target_id, strongest_similarity)

--- a/pattern_annotators/semantically_similar_pattern_extractor.py
+++ b/pattern_annotators/semantically_similar_pattern_extractor.py
@@ -7,7 +7,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "utils"))
 
 from transactions_manager import TransactionsManager
 from mutual_information_manager import MutualInformationManager
-from parse_patterns import parse_author_file_into_patterns
+from parse_patterns import parse_author_file_into_patterns, parse_sequential_title_file_into_patterns
 from cosine_similarity import compute_cosine_similarity
 
 class SemanticallySimilarPatternExtractor:
@@ -27,16 +27,20 @@ class SemanticallySimilarPatternExtractor:
         def __eq__(self, other):
             return self.sim == other.sim
 
-    def __init__(self, mutual_info_manager, transaction_manager,patterns):
+    def __init__(self, mutual_info_manager, transaction_manager, patterns, pattern_type):
         '''
         @param
             transaction_mananger: TransactionsManager       Object storing all transactions (every line from data.csv)
             mutual_info_manager: MutualInformationManager   Object storing a set of all author-author mutual information vals
             patterns: list(list(int))                       List of all SSP patterns
+            pattern_type: PatternType                       Type of pattern pairs to compute MI for
         '''
         self.__transaction_manager = transaction_manager
         self.__mutual_info_manager = mutual_info_manager
         self.__patterns = patterns
+        assert pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+            or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE
+        self.__pattern_type = pattern_type
 
     def find_semantically_similar_patterns(self, pattern_id, k):
         '''
@@ -68,27 +72,45 @@ class SemanticallySimilarPatternExtractor:
             ids of patterns to print out
         '''
         pattern = self.__patterns[pattern_id]
-        pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in pattern]
+
+        if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
+            pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in pattern]
+        elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+            pattern_words = [self.__transaction_manager.get_title_term(word_id) for word_id in pattern]
+
         print("Input pattern: %s" % ' '.join(pattern_words))
         for pattern_id in top_patterns:
             top_pattern = self.__patterns[pattern_id]
-            top_pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in top_pattern]
-            print("Pattern: %s" % ' '.join(top_pattern_words))
 
+            if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
+                top_pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in top_pattern]
+            elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+                top_pattern_words = [self.__transaction_manager.get_title_term(word_id) for word_id in top_pattern]
+            print("Pattern: %s" % ' '.join(top_pattern_words))
 
 if __name__ == '__main__':
     '''
-    Usage: py strongest_context_indicator_extractor.py [target_id] [k]
+    Usage: py strongest_context_indicator_extractor.py [target_id] [k] [is author experiment]
     '''
     target_id = int(sys.argv[1])
     k = int(sys.argv[2])
-
-    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR)
-    mutual_info.read_mutual_information_from_file()
+    is_auth_experiment = sys.argv[3] == "True"
 
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")
-    author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
+    if is_auth_experiment:
+        mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR)
+        mutual_info.read_mutual_information_from_file()
 
-    extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, author_patterns)
+        author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
+        extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, author_patterns, \
+            MutualInformationManager.PatternType.AUTHOR_AUTHOR)
+    else:
+        mutual_info = MutualInformationManager(MutualInformationManager.PatternType.TITLE_TITLE)
+        mutual_info.read_mutual_information_from_file()
+
+        title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
+        extractor =  SemanticallySimilarPatternExtractor(mutual_info, transactions, author_patterns, \
+            MutualInformationManager.PatternType.TITLE_TITLE)
+    
     strongest_similarity = extractor.find_semantically_similar_patterns(target_id, k)
     extractor.pretty_print(target_id, strongest_similarity)

--- a/pattern_annotators/strongest_context_indicator_extractor.py
+++ b/pattern_annotators/strongest_context_indicator_extractor.py
@@ -27,20 +27,31 @@ class StrongestContextIndicatorExtractor:
         def __eq__(self, other):
             return self.sim == other.sim
 
-    def __init__(self, mutual_info_manager, transaction_manager, patterns, pattern_type):
+    def __init__(self, mutual_info_manager, transaction_manager, patterns, pattern_type, alternate_patterns=None):
         '''
         @param
             transaction_mananger: TransactionsManager       Object storing all transactions (every line from data.csv)
             mutual_info_manager: MutualInformationManager   Object storing a set of all author-author mutual information vals
             patterns: list(list(int))                       List of all SSP patterns
             pattern_type: PatternType                       Type of pattern pairs to compute MI for
+            alternate_patterns list(list(int)):             If author-title or title-author, we pass in title/author patterns to
+                patterns and author/title patterns here
         '''
         self.__transaction_manager = transaction_manager
         self.__mutual_info_manager = mutual_info_manager
         self.__patterns = patterns
         assert pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
-            or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE
+            or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE \
+                or pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE \
+                    or pattern_type == MutualInformationManager.PatternType.TITLE_AUTHOR
+
         self.__pattern_type = pattern_type
+
+        if alternate_patterns:
+            assert pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE \
+                or pattern_type == MutualInformationManager.PatternType.TITLE_AUTHOR
+
+        self.__alternate_patterns = alternate_patterns
 
     def find_strongest_context_indicators(self, pattern_id, k):
         '''
@@ -69,20 +80,28 @@ class StrongestContextIndicatorExtractor:
         @param top_patterns list(int):
             ids of patterns to print out
         '''
-        pattern = self.__patterns[pattern_id]
+        if self.__alternate_patterns:
+            pattern = self.__alternate_patterns[pattern_id]
+        else:
+            pattern = self.__patterns[pattern_id]
 
-        if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
+        if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+            or self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE:
             pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in pattern]
-        elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+
+        elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE \
+            or self.__pattern_type == MutualInformationManager.PatternType.TITLE_AUTHOR:
             pattern_words = [self.__transaction_manager.get_title_term(word_id) for word_id in pattern]
 
         print("Input pattern: %s" % ' '.join(pattern_words))
         for pattern_id in top_patterns:
             top_pattern = self.__patterns[pattern_id]
 
-            if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
+            if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+                or self.__pattern_type == MutualInformationManager.PatternType.TITLE_AUTHOR:
                 top_pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in top_pattern]
-            elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+            elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE \
+                or self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE:
                 top_pattern_words = [self.__transaction_manager.get_title_term(word_id) for word_id in top_pattern]
             print("Pattern: %s" % ' '.join(top_pattern_words))
 
@@ -96,20 +115,43 @@ if __name__ == '__main__':
 
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")
 
+    author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
+    title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
+
     if is_auth_experiment:
+        # Annotate with author patterns
         mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR)
         mutual_info.read_mutual_information_from_file()
 
-        author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
         extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, author_patterns, \
             MutualInformationManager.PatternType.AUTHOR_AUTHOR)
+        strongest_indicators = extractor.find_strongest_context_indicators(target_id, k)
+        extractor.pretty_print(target_id, strongest_indicators)
+
+        # Annotate with title patterns
+        mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_TITLE)
+        mutual_info.read_mutual_information_from_file()
+
+        extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, title_patterns, \
+            MutualInformationManager.PatternType.AUTHOR_TITLE, author_patterns)
+        strongest_indicators = extractor.find_strongest_context_indicators(target_id, k)
+        extractor.pretty_print(target_id, strongest_indicators)
+
     else:
+        # Annotate with title patterns
         mutual_info = MutualInformationManager(MutualInformationManager.PatternType.TITLE_TITLE)
         mutual_info.read_mutual_information_from_file()
 
-        title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
         extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, title_patterns, \
             MutualInformationManager.PatternType.TITLE_TITLE)
-    
-    strongest_indicators = extractor.find_strongest_context_indicators(target_id, k)
-    extractor.pretty_print(target_id, strongest_indicators)
+        strongest_indicators = extractor.find_strongest_context_indicators(target_id, k)
+        extractor.pretty_print(target_id, strongest_indicators)
+
+        # Annotate with author patterns
+        mutual_info = MutualInformationManager(MutualInformationManager.PatternType.TITLE_AUTHOR)
+        mutual_info.read_mutual_information_from_file()
+
+        extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, author_patterns, \
+            MutualInformationManager.PatternType.TITLE_AUTHOR, title_patterns)
+        strongest_indicators = extractor.find_strongest_context_indicators(target_id, k)
+        extractor.pretty_print(target_id, strongest_indicators)

--- a/pattern_annotators/strongest_context_indicator_extractor.py
+++ b/pattern_annotators/strongest_context_indicator_extractor.py
@@ -107,9 +107,9 @@ if __name__ == '__main__':
         mutual_info = MutualInformationManager(MutualInformationManager.PatternType.TITLE_TITLE)
         mutual_info.read_mutual_information_from_file()
 
-        author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
-        extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, author_patterns, \
-            MutualInformationManager.PatternType.AUTHOR_AUTHOR)
+        title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
+        extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, title_patterns, \
+            MutualInformationManager.PatternType.TITLE_TITLE)
     
     strongest_indicators = extractor.find_strongest_context_indicators(target_id, k)
     extractor.pretty_print(target_id, strongest_indicators)

--- a/pattern_annotators/strongest_context_indicator_extractor.py
+++ b/pattern_annotators/strongest_context_indicator_extractor.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "utils"))
 
 from transactions_manager import TransactionsManager
 from mutual_information_manager import MutualInformationManager
-from parse_patterns import parse_author_file_into_patterns
+from parse_patterns import parse_author_file_into_patterns, parse_sequential_title_file_into_patterns
 from cosine_similarity import compute_cosine_similarity
 
 class StrongestContextIndicatorExtractor:
@@ -27,16 +27,20 @@ class StrongestContextIndicatorExtractor:
         def __eq__(self, other):
             return self.sim == other.sim
 
-    def __init__(self, mutual_info_manager, transaction_manager,patterns):
+    def __init__(self, mutual_info_manager, transaction_manager, patterns, pattern_type):
         '''
         @param
             transaction_mananger: TransactionsManager       Object storing all transactions (every line from data.csv)
             mutual_info_manager: MutualInformationManager   Object storing a set of all author-author mutual information vals
             patterns: list(list(int))                       List of all SSP patterns
+            pattern_type: PatternType                       Type of pattern pairs to compute MI for
         '''
         self.__transaction_manager = transaction_manager
         self.__mutual_info_manager = mutual_info_manager
         self.__patterns = patterns
+        assert pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+            or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE
+        self.__pattern_type = pattern_type
 
     def find_strongest_context_indicators(self, pattern_id, k):
         '''
@@ -59,34 +63,53 @@ class StrongestContextIndicatorExtractor:
         return ids
 
     def pretty_print(self, pattern_id, top_patterns):
-            '''
-            Takes in a list of pattern ids and converts them to printed patterns.
+        '''
+        Takes in a list of pattern ids and converts them to pattern names.
 
-            @param top_patterns list(int):
-                ids of patterns to print out
-            '''
-            pattern = self.__patterns[pattern_id]
+        @param top_patterns list(int):
+            ids of patterns to print out
+        '''
+        pattern = self.__patterns[pattern_id]
+
+        if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
             pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in pattern]
-            print("Input pattern: %s" % ' '.join(pattern_words))
+        elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+            pattern_words = [self.__transaction_manager.get_title_term(word_id) for word_id in pattern]
 
-            for top_pattern_id in top_patterns:
-                top_pattern = self.__patterns[top_pattern_id]
+        print("Input pattern: %s" % ' '.join(pattern_words))
+        for pattern_id in top_patterns:
+            top_pattern = self.__patterns[pattern_id]
+
+            if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
                 top_pattern_words = [self.__transaction_manager.get_author_name(word_id) for word_id in top_pattern]
-                print("Pattern: %s" % ' '.join(top_pattern_words))
+            elif self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+                top_pattern_words = [self.__transaction_manager.get_title_term(word_id) for word_id in top_pattern]
+            print("Pattern: %s" % ' '.join(top_pattern_words))
 
 if __name__ == '__main__':
     '''
-    Usage: py strongest_context_indicator_extractor.py [target_id] [k]
+    Usage: py strongest_context_indicator_extractor.py [target_id] [k] [is author experiment]
     '''
     target_id = int(sys.argv[1])
     k = int(sys.argv[2])
-
-    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR)
-    mutual_info.read_mutual_information_from_file()
+    is_auth_experiment = sys.argv[3] == "True"
 
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")
-    author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
 
-    extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, author_patterns)
+    if is_auth_experiment:
+        mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR)
+        mutual_info.read_mutual_information_from_file()
+
+        author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
+        extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, author_patterns, \
+            MutualInformationManager.PatternType.AUTHOR_AUTHOR)
+    else:
+        mutual_info = MutualInformationManager(MutualInformationManager.PatternType.TITLE_TITLE)
+        mutual_info.read_mutual_information_from_file()
+
+        author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
+        extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, author_patterns, \
+            MutualInformationManager.PatternType.AUTHOR_AUTHOR)
+    
     strongest_indicators = extractor.find_strongest_context_indicators(target_id, k)
     extractor.pretty_print(target_id, strongest_indicators)

--- a/pattern_annotators/strongest_context_indicator_extractor.py
+++ b/pattern_annotators/strongest_context_indicator_extractor.py
@@ -6,7 +6,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "..", "utils"))
 
 from transactions_manager import TransactionsManager
 from mutual_information_manager import MutualInformationManager
-from parse_patterns import parse_file_into_patterns
+from parse_patterns import parse_author_file_into_patterns
 from cosine_similarity import compute_cosine_similarity
 
 class StrongestContextIndicatorExtractor:
@@ -80,10 +80,12 @@ if __name__ == '__main__':
     '''
     target_id = int(sys.argv[1])
     k = int(sys.argv[2])
-    mutual_info = MutualInformationManager()
+
+    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR)
     mutual_info.read_mutual_information_from_file()
+
     transactions = TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")
-    author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
+    author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
 
     extractor = StrongestContextIndicatorExtractor(mutual_info, transactions, author_patterns)
     strongest_indicators = extractor.find_strongest_context_indicators(target_id, k)

--- a/setup.sh
+++ b/setup.sh
@@ -34,7 +34,7 @@ echo "Computing author-author pattern mutual information cache"
 python utils/mutual_information_manager.py
 
 echo "Checking to make sure all required files exist"
-declare -a required_files=("data/frequent_author_patterns.txt" "data/author_id_mappings.txt" "data/title_term_id_mappings.txt" "data/title_term_id_mappings.txt", "data/author_mutual_info_patterns.txt")
+declare -a required_files=("data/frequent_author_patterns.txt" "data/author_id_mappings.txt" "data/title_term_id_mappings.txt" "data/title_term_id_mappings.txt" "data/author_author_mutual_info_patterns.txt" "data/author_title_mutual_info_patterns.txt" "data/title_title_mutual_info_patterns.txt")
 for i in "${required_files[@]}"
 do
 if [ -e $i ]

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -1,6 +1,6 @@
 from math import log2
 import transactions_manager
-from parse_patterns import parse_file_into_patterns
+from parse_patterns import parse_author_file_into_patterns, parse_sequential_title_file_into_patterns
 
 import os
 
@@ -13,7 +13,11 @@ Usage:
 
 Output file format:
     index1 index2 MI
-where index1 <= index2
+where index1 <= index2 for auth-auth or title-title managers
+
+Output file format:
+    index1 index2 MI
+where index1 = author index and index2 = title index for auth-title managers
 
 * To read the mutual info file into this class and to get the mutual information given a
   pair of indices
@@ -67,13 +71,24 @@ class MutualInformationManager:
         (aka that it was generated using this file)
         '''
         mutual_info_file = open(self.__filename, "r")
+        is_first = True
         for line in mutual_info_file:
+            if is_first:
+                pattern_type = int(line.strip())
+                assert pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+                    or pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE \
+                        or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE
+                self.__pattern_type = pattern_type
+
             mutual_info_lst = line.strip().split()
             assert len(mutual_info_lst) == 3
 
             ind_x = int(mutual_info_lst[0])
             ind_y = int(mutual_info_lst[1])
-            assert ind_x <= ind_y
+            
+            if pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+                or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+                assert ind_x <= ind_y
 
             self.__mutual_info_vals[(ind_x, ind_y)] = float(mutual_info_lst[2])
         mutual_info_file.close()
@@ -88,6 +103,8 @@ class MutualInformationManager:
 
         # Format: pattern_ind_1 pattern_ind_2 MI
         mutual_info_file = open(self.__pattern_type, "w")
+        mutual_info_file.write("%d\n" % self.__pattern_type)
+
         for pattern_ind_x, pattern_ind_y in self.__mutual_info_vals:
             mutual_info_file.write("%d %d %f\n" % (pattern_ind_x, pattern_ind_y, \
                 self.__mutual_info_vals[(pattern_ind_x, pattern_ind_y)]))
@@ -99,21 +116,25 @@ class MutualInformationManager:
         computes a triangular matrix of mutual information values bc MI is symmetric
 
         @param
-            patterns: list(list(int))               List of patterns to compute MI over
+            patterns: list(list(int))               List of patterns to compute MI over. MUST be author patterns
+                    if pattern type is AUTHOR_TITLE
+
             secondary_patterns: list(list(int))?    List of secondary patterns to compute MI over if 
                     patterns != secondary patterns (then, we'd compute the MI for each (pattern, secondary pattern)
-                    pair). Only non-null if pattern type is AUTHOR_TITLE
+                    pair). Only non-null if pattern type is AUTHOR_TITLE. MUST BE TITLE PATTERNS IF NON-NULL
         '''
         if not self.__transactions:
             print("ERROR: You can't compute mutual information with a null transactions manager")
             exit(1)
 
-        if secondary_patterns and self.__pattern_type != MutualInformationManager.PatternType.AUTHOR_TITLE:
-            print("ERROR: You can only pass in a secondary pattern list if the Pattern Type is AUTHOR_TITLE")
+        if (secondary_patterns and self.__pattern_type != MutualInformationManager.PatternType.AUTHOR_TITLE) \
+            or (not secondary_patterns and self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE):
+            print("ERROR: You must and can only pass in a secondary pattern list if the Pattern Type is AUTHOR_TITLE")
             exit(1)
-
+        
         if self.__write_to_file_during_computation:
             mutual_info_file = open(self.__filename, "w")
+            mutual_info_file.write("%d\n" % self.__pattern_type)
 
         for ind_x, pattern_x in enumerate(patterns):
             if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE:
@@ -124,7 +145,7 @@ class MutualInformationManager:
             for ind_y in pattern_itr:
                 self.__mutual_info_vals[(ind_x, ind_y)] = \
                     MutualInformationManager.compute_mutual_information_for_pattern_pair(self.__transactions, \
-                        pattern_x, patterns[ind_y])
+                        self.__pattern_type, pattern_x, patterns[ind_y])
 
                 if self.__write_to_file_during_computation:
                     mutual_info_file.write("%d %d %f\n" % (ind_x, ind_y, \
@@ -138,7 +159,7 @@ class MutualInformationManager:
         computed/read in.
 
         @param
-            pattern_ind: int              Pattern index to find MI vec for
+            pattern_ind: int              Pattern index to find MI vec for. Must be author if non-null
             context_model_dim: int        Dimension of context vector
 
         @return mutual information val, which is represented as list(float)
@@ -151,7 +172,8 @@ class MutualInformationManager:
     def get_mutual_information(self, pattern_index_x, pattern_index_y):
         '''
         Get precomputed mutual information value given 2 indices. Assumes that the mutual info matrix has been
-        computed/read in. Doesn't assume that one index is greater than another
+        computed/read in. Doesn't assume that one index is greater than another. Note: pattern_index_x must be
+        for authors and pattern_index_y for titles if the pattern type is author-title
 
         @param
             pattern_index_x: int        Pattern index to find MI for
@@ -159,20 +181,26 @@ class MutualInformationManager:
 
         @return mutual information val, which is represented as a float
         '''
-        if pattern_index_x <= pattern_index_y:
-            ind_tup = (pattern_index_x, pattern_index_y)
+        if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+            or self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+            if pattern_index_x <= pattern_index_y:
+                ind_tup = (pattern_index_x, pattern_index_y)
+            else:
+                ind_tup = (pattern_index_y, pattern_index_x)
         else:
-            ind_tup = (pattern_index_y, pattern_index_x)
+            ind_tup = (pattern_index_x, pattern_index_y)
         return self.__mutual_info_vals[ind_tup]
 
     @staticmethod
-    def compute_mutual_information_for_pattern_pair(transaction_manager, pattern_x, pattern_y):
+    def compute_mutual_information_for_pattern_pair(transaction_manager, pattern_type, pattern_x, pattern_y):
         '''
         Computes mutual information value given patterns using the transaction manager.
 
         @param
-            pattern_x: vec[int]        Pattern of author IDs to find MI for
-            pattern_y: vec[int]        Pattern of author IDs to find MI for
+            transaction_manager: TransactionManager transaction manager storing parsed paper data
+            pattern_type: PatternType               type of pattern pairs to compute MI for
+            pattern_x: vec[int]                     Pattern of author IDs to find MI for
+            pattern_y: vec[int]                     Pattern of author IDs to find MI for
 
         @return mutual information val, which is represented as a float
         '''
@@ -184,8 +212,18 @@ class MutualInformationManager:
         pattern_x_set = set(pattern_x)
         pattern_y_set = set(pattern_y)
 
-        x_paper_inds = transaction_manager.find_author_pattern_transactions_ids(pattern_x_set)
-        y_paper_inds = transaction_manager.find_author_pattern_transactions_ids(pattern_y_set)
+        if pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR:
+            x_paper_inds = transaction_manager.find_author_pattern_transactions_ids(pattern_x_set)
+            y_paper_inds = transaction_manager.find_author_pattern_transactions_ids(pattern_y_set)
+
+        elif pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE:
+            x_paper_inds = transaction_manager.find_author_pattern_transactions_ids(pattern_x_set)
+            y_paper_inds = transaction_manager.find_title_pattern_transactions_ids(pattern_y_set)
+
+        elif pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+            x_paper_inds = transaction_manager.find_title_pattern_transactions_ids(pattern_x_set)
+            y_paper_inds = transaction_manager.find_title_pattern_transactions_ids(pattern_y_set)
+
         x_support = len(x_paper_inds)
         y_support = len(y_paper_inds)
 
@@ -221,9 +259,10 @@ class MutualInformationManager:
 
 if __name__ == "__main__":
     transactions = transactions_manager.TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
-    author_patterns = parse_file_into_patterns("data/frequent_author_patterns.txt")
-    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR, transactions, True)
-    mutual_info.compute_mutual_information(author_patterns)
+    author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
+    title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
+    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_TITLE, transactions, True)
+    mutual_info.compute_mutual_information(author_patterns, title_patterns)
     
     #mutual_info = MutualInformationManager()
     #mutual_info.read_mutual_information_from_file()

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -78,7 +78,10 @@ class MutualInformationManager:
                 assert pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
                     or pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE \
                         or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE
+
                 self.__pattern_type = pattern_type
+                is_first = False
+                continue
 
             mutual_info_lst = line.strip().split()
             assert len(mutual_info_lst) == 3
@@ -261,8 +264,11 @@ if __name__ == "__main__":
     transactions = transactions_manager.TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
     author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
     title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
-    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_TITLE, transactions, True)
-    mutual_info.compute_mutual_information(author_patterns, title_patterns)
-    
+    #mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_TITLE, transactions, True)
+    #mutual_info.compute_mutual_information(author_patterns, title_patterns)
+
+    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR, transactions, True)
+    mutual_info.compute_mutual_information(author_patterns)
+
     #mutual_info = MutualInformationManager()
     #mutual_info.read_mutual_information_from_file()

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -280,11 +280,18 @@ if __name__ == "__main__":
     transactions = transactions_manager.TransactionsManager("data/data.csv", "data/author_id_mappings.txt", "data/title_term_id_mappings.txt")    
     author_patterns = parse_author_file_into_patterns("data/frequent_author_patterns.txt")
     title_patterns = parse_sequential_title_file_into_patterns("data/minimal_title_term_patterns.txt")
-    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.TITLE_AUTHOR, transactions, True)
+
+    print("Author author")
+    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR, transactions, True)
+    mutual_info.compute_mutual_information(author_patterns)
+
+    print("Author title")
+    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_TITLE, transactions, True)
     mutual_info.compute_mutual_information(author_patterns, title_patterns)
 
-    #mutual_info = MutualInformationManager(MutualInformationManager.PatternType.AUTHOR_AUTHOR, transactions, True)
-    #mutual_info.compute_mutual_information(author_patterns)
+    print("Title title")
+    mutual_info = MutualInformationManager(MutualInformationManager.PatternType.TITLE_TITLE, transactions, True)
+    mutual_info.compute_mutual_information(title_patterns)
 
     #mutual_info = MutualInformationManager()
     #mutual_info.read_mutual_information_from_file()

--- a/utils/mutual_information_manager.py
+++ b/utils/mutual_information_manager.py
@@ -76,12 +76,14 @@ class MutualInformationManager:
         for line in mutual_info_file:
             if is_first:
                 pattern_type = int(line.strip())
-                assert pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
-                    or pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE \
-                        or pattern_type == MutualInformationManager.PatternType.TITLE_AUTHOR \
-                            or pattern_type == MutualInformationManager.PatternType.TITLE_TITLE
 
-                self.__pattern_type = pattern_type
+                if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_AUTHOR \
+                    or self.__pattern_type == MutualInformationManager.PatternType.TITLE_TITLE:
+                    assert pattern_type == self.__pattern_type
+                elif pattern_type == MutualInformationManager.PatternType.TITLE_AUTHOR \
+                    or pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE:
+                    assert pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE
+
                 is_first = False
                 continue
 
@@ -144,7 +146,8 @@ class MutualInformationManager:
             mutual_info_file.write("%d\n" % self.__pattern_type)
 
         for ind_x, pattern_x in enumerate(patterns):
-            if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE:
+            if self.__pattern_type == MutualInformationManager.PatternType.AUTHOR_TITLE \
+                or self.__pattern_type == MutualInformationManager.PatternType.TITLE_AUTHOR:
                 pattern_itr = range(len(secondary_patterns))
             else:
                 pattern_itr = range(ind_x, len(patterns))
@@ -173,6 +176,7 @@ class MutualInformationManager:
         @return mutual information val, which is represented as list(float)
         '''
         mi_vec = []
+
         for other_pattern_ind in range(context_model_dim):
             # TITLE-AUTH and AUTH-TITle = implemented in the same way, so we need to swap the indices here when calling 
             # get_mutual_information

--- a/utils/parse_patterns.py
+++ b/utils/parse_patterns.py
@@ -1,6 +1,6 @@
 def parse_author_file_into_patterns(pattern_file_name):
     '''
-    Parse a file generated via build_frequent_patterns.py into a list of patterns
+    Parse an author file generated via build_frequent_patterns.py into a list of patterns
     
     @param pattern_file_name: string    Input file name
         Format assumption: item_id_1 item_id_2 item_id_3 #SUP support
@@ -16,6 +16,32 @@ def parse_author_file_into_patterns(pattern_file_name):
         assert sup_ind != -1
         pattern_lst = line[ : sup_ind].split()
         patterns.append([int(item) for item in pattern_lst])
+
+    pattern_file.close()
+    return patterns
+
+def parse_sequential_title_file_into_patterns(pattern_file_name):
+    '''
+    Parse a title file generated via build_frequent_patterns.py into a list of patterns
+    
+    @param pattern_file_name: string    Input file name
+        Format assumption: item_id_1 item_id_2 item_id_3 #SUP support
+        One pattern/line
+    @return list(list(int)), representing all patterns parsed from file where each inner list
+        is a pattern of item ids (recall that words are being mapped to integer ids)
+    '''
+    pattern_file = open(pattern_file_name, "r")
+    
+    patterns = []
+    for line in pattern_file:
+        pattern_lst = line.split()
+        pattern = []        
+
+        for item in pattern_lst:
+            item = int(item)
+            if item != -1:
+                pattern.append(item)
+        patterns.append(pattern)
 
     pattern_file.close()
     return patterns

--- a/utils/parse_patterns.py
+++ b/utils/parse_patterns.py
@@ -1,4 +1,4 @@
-def parse_file_into_patterns(pattern_file_name):
+def parse_author_file_into_patterns(pattern_file_name):
     '''
     Parse a file generated via build_frequent_patterns.py into a list of patterns
     

--- a/utils/remove_redundant_patterns.py
+++ b/utils/remove_redundant_patterns.py
@@ -3,7 +3,7 @@ import os
 sys.path.insert(1, os.path.join('utils', 'frequent_pattern_mining'))
 
 from build_frequent_patterns import FrequentPatternBuilder
-from parse_patterns import parse_file_into_patterns, write_patterns_to_file
+from parse_patterns import parse_author_file_into_patterns, write_patterns_to_file
 
 '''
 Utility methods for 
@@ -185,6 +185,6 @@ def find_one_pass_microclustering_patterns(patterns, dist_thresh = 0.9):
     return min_intra_dist_patterns
 
 if __name__ == "__main__":
-    title_patterns = parse_file_into_patterns(FrequentPatternBuilder.TITLE_TERMS_OUTPUT_FILE_PATH)
+    title_patterns = parse_author_file_into_patterns(FrequentPatternBuilder.TITLE_TERMS_OUTPUT_FILE_PATH)
     minimal_patterns = find_one_pass_microclustering_patterns(title_patterns, 0.6)
     write_patterns_to_file(MINIMAL_TITLE_TERMS_FILENAME, minimal_patterns)

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -46,7 +46,10 @@ class TransactionsManager:
 
         self.__papers = []
 
+        i=0
         for line in papers_file:
+            i+=1
+            if i == 11:break
             # Note: Titles are guaranteed to not have commas
             line_as_lst = line.split(',')
             authors = line_as_lst[ : -1]

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -63,9 +63,34 @@ class TransactionsManager:
 
         papers_file.close()
 
+    def compute_title_context_models(self, patterns):
+        '''
+        Computes context models for each paper's title terms against title patterns
+        @param
+            patterns: list(list(int))         List of all frequent title patterns
+        @return
+            context_models: list(list(float)) List of all context models, one per paper
+        '''
+        context_models = []
+
+        num_transactions = self.get_number_of_transactions()
+        for paper_id in range(num_transactions):
+            paper_context_model = []
+
+            for pattern in patterns:
+                paper_titles = self.get_paper_title_terms(paper_id)
+                mutual_info = \
+                    mutual_information_manager.MutualInformationManager.compute_mutual_information_for_pattern_pair(self, \
+                        mutual_information_manager.MutualInformationManager.PatternType.TITLE_TITLE, \
+                             pattern, paper_titles)
+                paper_context_model.append(mutual_info)
+
+            context_models.append(paper_context_model)
+        return context_models
+
     def compute_author_context_models(self, patterns):
         '''
-        Computes context models for each paper's authors
+        Computes context models for each paper's authors against author patterns
         @param
             patterns: list(list(int))         List of all frequent author patterns
         @return

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -87,6 +87,26 @@ class TransactionsManager:
             context_models.append(paper_context_model)
         return context_models
 
+    def find_title_pattern_transactions_ids(self, title_pattern):
+        '''
+        Find transactions that have title pattern as a subset
+
+        @param:
+            title_pattern: list(int)     Ordered list of title ids
+        '''
+        # https://stackoverflow.com/questions/24017363/how-to-test-if-one-string-is-a-subsequence-of-another
+        def is_subseq(x, y):
+            it = iter(y)
+            return all(any(c == ch for c in it) for ch in x)
+
+        title_transactions = set()
+        for ind, paper in enumerate(self.__papers):
+            # Title patterns are sequential so we need to ensure that the order is there
+            # Check that the title is a subsequence of paper.title
+            if is_subseq(title_pattern, paper.title):
+                title_transactions.add(ind)
+        return title_transactions
+
     def find_author_pattern_transactions_ids(self, author_pattern):
         '''
         Find transactions that have author pattern as a subset

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -46,10 +46,7 @@ class TransactionsManager:
 
         self.__papers = []
 
-        i=0
         for line in papers_file:
-            i+=1
-            if i == 11:break
             # Note: Titles are guaranteed to not have commas
             line_as_lst = line.split(',')
             authors = line_as_lst[ : -1]

--- a/utils/transactions_manager.py
+++ b/utils/transactions_manager.py
@@ -81,7 +81,8 @@ class TransactionsManager:
                 paper_authors = self.get_paper_authors(paper_id)
                 mutual_info = \
                     mutual_information_manager.MutualInformationManager.compute_mutual_information_for_pattern_pair(self, \
-                        pattern, paper_authors)
+                        mutual_information_manager.MutualInformationManager.PatternType.AUTHOR_AUTHOR, \
+                             pattern, paper_authors)
                 paper_context_model.append(mutual_info)
 
             context_models.append(paper_context_model)


### PR DESCRIPTION
# Summary
* Add command line support for annotating title patterns
* Add parser for title patterns
* Add support for author-title/title-title/title-author mutual info managers -- note that title-author and author-title produce the same cache file but there's still a difference when it comes to getting the mutual info vector (whether we're getting it wrt the title or wrt the author)

# Testing
Truncate transactions manager to read in the first 10 papers in data.csv only for the sake of time.
## pattern_annotators/representative_transaction_extractor.py
![Screen Shot 2020-11-25 at 10 07 46 AM](https://user-images.githubusercontent.com/13123675/100266126-29a63600-2f06-11eb-8848-a70500da1506.png)

## pattern_annotators/semantically_similar_pattern_extractor.py
![Screen Shot 2020-11-25 at 10 08 42 AM](https://user-images.githubusercontent.com/13123675/100266166-37f45200-2f06-11eb-8e0c-8fc4f2375166.png)

## pattern_annotators/strongest_context_indicator_extractor.py
![Screen Shot 2020-11-25 at 10 40 48 AM](https://user-images.githubusercontent.com/13123675/100268980-b3580280-2f0a-11eb-8e3f-fd559d2f186e.png)

![Screen Shot 2020-11-25 at 10 40 09 AM](https://user-images.githubusercontent.com/13123675/100268949-a6d3aa00-2f0a-11eb-9ebe-240882fc5429.png)
